### PR TITLE
Added 3 pre-built methods to resolve the issue in the Yup validation

### DIFF
--- a/web/src/app/[entity]/counter/page.tsx
+++ b/web/src/app/[entity]/counter/page.tsx
@@ -30,11 +30,12 @@ const validationSchema = Yup.object().shape({
       let hasDuplicate = false;
 
       value?.forEach(service => {
-        if (serviceNames.has(service.name)) {
+        const serviceName = (service.name || '').replace(/\s+/g, '').trim().toLowerCase();
+        if (serviceNames.has(serviceName)) {
           hasDuplicate = true;
           return;
         }
-        serviceNames.add(service.name);
+        serviceNames.add(serviceName);
       });
 
       return !hasDuplicate;


### PR DESCRIPTION
**Task:**
Fixing Bug in Duplicate Service Name Validation

**Why:**
The current implementation of the validation logic for duplicate service names has a flaw where similar strings with different cases and spacings are treated as distinct. This leads to incorrect validation results and potentially allows the creation of duplicate service names, undermining data integrity. Fixing this bug is crucial to ensure accurate validation and prevent data duplication, thereby maintaining the integrity of the system.

**How:**
To address this issue, I have modified the validation logic to normalize service names by removing extra whitespace and converting them to lowercase before checking for duplicates. This normalization process ensures that similar strings with variations in cases and spacings are treated as identical, effectively resolving the bug. By implementing this fix, we ensure that the validation accurately identifies and prevents the creation of duplicate service names, thereby enhancing the reliability and integrity of the system.